### PR TITLE
wrap DROP TABLE with BEGIN/END (sql syntax error on some editors)

### DIFF
--- a/Security Audit/tsqltools_AllInOneSecurityAudit.sql
+++ b/Security Audit/tsqltools_AllInOneSecurityAudit.sql
@@ -108,7 +108,7 @@ INSERT INTO #result
   FROM #datadirectory
 
 IF OBJECT_ID('tempdb.dbo.#StartupType', 'U') IS NOT NULL
-  DROP TABLE #startuptype
+   begin  DROP TABLE #startuptype end
 
 CREATE TABLE #startuptype (
   sqlservice varchar(50),


### PR DESCRIPTION
wrap DROP TABLE with BEGIN/END (sql syntax error on some editors)
Tested on SSMS 2017 & VSCode